### PR TITLE
make address modal a component

### DIFF
--- a/src/components/add-address-modal/index.tsx
+++ b/src/components/add-address-modal/index.tsx
@@ -1,0 +1,324 @@
+import { useState, useEffect } from "react";
+import {
+    MDBModal,
+    MDBModalDialog,
+    MDBModalContent,
+    MDBModalHeader,
+    MDBModalBody,
+    MDBModalFooter,
+    MDBBtn,
+    MDBInput,
+    MDBModalTitle,
+} from "mdb-react-ui-kit";
+import addressService from "@/service/address-service.ts";
+import { ButtonWithProgress } from "@/components/button-with-progress";
+import { IAddress } from "@/commons/interfaces.ts";
+
+// Define a specific type for your address errors.
+interface AddressErrors {
+    street: string;
+    number: string;
+    complement: string;
+    neighborhood: string;
+    city: string;
+    state: string;
+    country: string;
+    zip: string;
+}
+
+interface AddAddressModalProps {
+    modalOpen: boolean;
+    setModalOpen: (open: boolean) => void;
+    onAddressSaved: () => void;
+    addressToEdit?: IAddress;
+}
+
+export function AddAddressModal({
+                                    modalOpen,
+                                    setModalOpen,
+                                    onAddressSaved,
+                                    addressToEdit,
+                                }: AddAddressModalProps) {
+    const [newAddress, setNewAddress] = useState<IAddress>({
+        street: "",
+        number: "" as unknown as number,
+        complement: "",
+        neighborhood: "",
+        city: "",
+        state: "",
+        country: "",
+        zip: "",
+    });
+
+    // Use the AddressErrors type in state.
+    const [addressErrors, setAddressErrors] = useState<AddressErrors>({
+        street: "",
+        number: "",
+        complement: "",
+        neighborhood: "",
+        city: "",
+        state: "",
+        country: "",
+        zip: "",
+    });
+
+    const [pendingApiCall, setPendingApiCall] = useState(false);
+    const [apiError, setApiError] = useState(false);
+    const [apiSuccess, setApiSuccess] = useState(false);
+
+    useEffect(() => {
+        if (addressToEdit) {
+            setNewAddress(addressToEdit);
+        } else {
+            setNewAddress({
+                street: "",
+                number: "" as unknown as number,
+                complement: "",
+                neighborhood: "",
+                city: "",
+                state: "",
+                country: "",
+                zip: "",
+            });
+        }
+    }, [addressToEdit]);
+
+    const handleAddressChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+        const { name, value } = event.target;
+        setNewAddress((prev) => ({
+            ...prev,
+            [name]: value,
+        }));
+        setAddressErrors((prev) => ({
+            ...prev,
+            [name]: "",
+        }));
+    };
+
+    const handleZipBlur = async () => {
+        if (newAddress.zip.length === 8) {
+            const addressData = await addressService.getAddressByCEP(newAddress.zip);
+            if (addressData) {
+                setNewAddress((prev) => ({
+                    ...prev,
+                    street: addressData.logradouro,
+                    neighborhood: addressData.bairro,
+                    city: addressData.localidade,
+                    state: addressData.uf,
+                    country: "Brasil",
+                }));
+            }
+        }
+    };
+
+    // Validation function using the AddressErrors type.
+    const validate = (): boolean => {
+        const errors: AddressErrors = {
+            street: "",
+            number: "",
+            complement: "",
+            neighborhood: "",
+            city: "",
+            state: "",
+            country: "",
+            zip: "",
+        };
+
+        // Validate ZIP code: must be exactly 8 digits.
+        const zipDigits = newAddress.zip.replace(/\D/g, "");
+        if (zipDigits.length !== 8) {
+            errors.zip = "ZIP code must be exactly 8 digits";
+        }
+
+        // Validate Number: must not be empty and must be a valid number.
+        if (!newAddress.number || isNaN(Number(newAddress.number))) {
+            errors.number = "Number must be a valid numeric value";
+        }
+
+        // Optionally validate other required fields.
+        if (!newAddress.street.trim()) {
+            errors.street = "Street is required";
+        }
+        if (!newAddress.city.trim()) {
+            errors.city = "City is required";
+        }
+        if (!newAddress.state.trim()) {
+            errors.state = "State is required";
+        }
+        if (!newAddress.country.trim()) {
+            errors.country = "Country is required";
+        }
+
+        setAddressErrors(errors);
+
+        // If there are no errors (all values are empty strings), return true.
+        return Object.values(errors).every((error) => error === "");
+    };
+
+    const handleSaveAddress = async () => {
+        // Run client-side validation first.
+        if (!validate()) {
+            return;
+        }
+
+        setPendingApiCall(true);
+        setApiError(false);
+        setApiSuccess(false);
+
+        const addressToSave = {
+            ...newAddress,
+            // Convert the number field from string to number.
+            number: parseInt(newAddress.number as unknown as string) || 0,
+        };
+
+        let response;
+        if (newAddress.id) {
+            response = await addressService.update(addressToSave);
+        } else {
+            response = await addressService.save(addressToSave);
+        }
+
+        if (response.status === 200 || response.status === 201) {
+            setApiSuccess(true);
+            setTimeout(() => {
+                setModalOpen(false);
+                onAddressSaved();
+            }, 2000);
+        } else {
+            if (response.data.validationErrors) {
+                setAddressErrors(response.data.validationErrors);
+            }
+            setApiError(true);
+            setPendingApiCall(false);
+        }
+    };
+
+    return (
+        <MDBModal open={modalOpen} setOpen={setModalOpen} tabIndex="-1">
+            <MDBModalDialog>
+                <MDBModalContent>
+                    <MDBModalHeader>
+                        <MDBModalTitle>
+                            {addressToEdit ? "Edit Address" : "Add New Address"}
+                        </MDBModalTitle>
+                        <MDBBtn
+                            className="btn-close"
+                            color="none"
+                            onClick={() => setModalOpen(false)}
+                        ></MDBBtn>
+                    </MDBModalHeader>
+                    <MDBModalBody>
+                        <MDBInput
+                            className={`mb-3 ${addressErrors.zip ? "is-invalid" : ""}`}
+                            label="ZIP Code"
+                            value={newAddress.zip.replace(/\D/g, "")}
+                            onChange={handleAddressChange}
+                            onBlur={handleZipBlur}
+                            name="zip"
+                        />
+                        {addressErrors.zip && (
+                            <div className="invalid-feedback">{addressErrors.zip}</div>
+                        )}
+                        <MDBInput
+                            className={`mb-3 ${addressErrors.street ? "is-invalid" : ""}`}
+                            label="Street"
+                            value={newAddress.street}
+                            onChange={handleAddressChange}
+                            name="street"
+                        />
+                        {addressErrors.street && (
+                            <div className="invalid-feedback">{addressErrors.street}</div>
+                        )}
+                        <MDBInput
+                            className={`mb-3 ${addressErrors.number ? "is-invalid" : ""}`}
+                            label="Number"
+                            type="number"
+                            value={
+                                typeof newAddress.number === "number"
+                                    ? newAddress.number === 0
+                                        ? ""
+                                        : newAddress.number.toString()
+                                    : newAddress.number
+                            }
+                            onChange={handleAddressChange}
+                            name="number"
+                        />
+                        {addressErrors.number && (
+                            <div className="invalid-feedback">{addressErrors.number}</div>
+                        )}
+                        <MDBInput
+                            className={`mb-3 ${addressErrors.complement ? "is-invalid" : ""}`}
+                            label="Complement"
+                            value={newAddress.complement}
+                            onChange={handleAddressChange}
+                            name="complement"
+                        />
+                        {addressErrors.complement && (
+                            <div className="invalid-feedback">{addressErrors.complement}</div>
+                        )}
+                        <MDBInput
+                            className={`mb-3 ${addressErrors.neighborhood ? "is-invalid" : ""}`}
+                            label="Neighborhood"
+                            value={newAddress.neighborhood}
+                            onChange={handleAddressChange}
+                            name="neighborhood"
+                        />
+                        {addressErrors.neighborhood && (
+                            <div className="invalid-feedback">{addressErrors.neighborhood}</div>
+                        )}
+                        <MDBInput
+                            className={`mb-3 ${addressErrors.city ? "is-invalid" : ""}`}
+                            label="City"
+                            value={newAddress.city}
+                            onChange={handleAddressChange}
+                            name="city"
+                        />
+                        {addressErrors.city && (
+                            <div className="invalid-feedback">{addressErrors.city}</div>
+                        )}
+                        <MDBInput
+                            className={`mb-3 ${addressErrors.state ? "is-invalid" : ""}`}
+                            label="State"
+                            value={newAddress.state}
+                            onChange={handleAddressChange}
+                            name="state"
+                        />
+                        {addressErrors.state && (
+                            <div className="invalid-feedback">{addressErrors.state}</div>
+                        )}
+                        <MDBInput
+                            className={`mb-3 ${addressErrors.country ? "is-invalid" : ""}`}
+                            label="Country"
+                            value={newAddress.country}
+                            onChange={handleAddressChange}
+                            name="country"
+                        />
+                        {addressErrors.country && (
+                            <div className="invalid-feedback">{addressErrors.country}</div>
+                        )}
+                    </MDBModalBody>
+                    <MDBModalFooter>
+                        <MDBBtn color="secondary" onClick={() => setModalOpen(false)}>
+                            Close
+                        </MDBBtn>
+                        <ButtonWithProgress
+                            disabled={pendingApiCall}
+                            pendingApiCall={pendingApiCall}
+                            className="btn btn-primary"
+                            text={addressToEdit ? "Save Changes" : "Save Address"}
+                            onClick={handleSaveAddress}
+                        />
+                    </MDBModalFooter>
+                    {apiError && (
+                        <div className="alert alert-danger">Failed to save address!</div>
+                    )}
+                    {apiSuccess && (
+                        <div className="alert alert-success">
+                            Address saved successfully!
+                        </div>
+                    )}
+                </MDBModalContent>
+            </MDBModalDialog>
+        </MDBModal>
+    );
+}

--- a/src/pages/user/index.tsx
+++ b/src/pages/user/index.tsx
@@ -1,185 +1,87 @@
+// File: src/pages/UserPage.tsx
 import { useState, useEffect } from "react";
 import {
   MDBBtn,MDBListGroup,MDBTabsPane,  MDBTabsContent,MDBTabsLink,MDBTabsItem,MDBTabs,
   MDBListGroupItem,MDBCard, MDBCardBody, MDBCardTitle, MDBCardText, MDBRow, MDBCol,
-  MDBModalContent, MDBModalHeader, MDBModalBody, MDBModal, MDBModalDialog, MDBModalTitle, MDBInput, MDBModalFooter
 } from "mdb-react-ui-kit";
-import {IAddress, IOrder, IUser} from "@/commons/interfaces.ts";
+import { IAddress, IOrder, IUser } from "@/commons/interfaces.ts";
 import userService from "@/service/user-service.ts";
 import addressService from "@/service/address-service.ts";
 import orderService from "@/service/order-service.ts";
-import {ButtonWithProgress} from "@/components/button-with-progress";
+import { AddAddressModal } from "@/components/add-address-modal";
 
 export function UserPage() {
-  const [justifyActive, setJustifyActive] = useState('tab1');
+  const [justifyActive, setJustifyActive] = useState("tab1");
   const [user, setUser] = useState<IUser | null>(null);
   const [addresses, setAddresses] = useState<IAddress[]>([]);
   const [orders, setOrders] = useState<IOrder[]>([]);
   const [modalOpen, setModalOpen] = useState(false);
-  const [pendingApiCall, setPendingApiCall] = useState(false);
-  const [apiError, setApiError] = useState(false);
-  const [apiSuccess, setApiSuccess] = useState(false);
-  const [newAddress, setNewAddress] = useState<IAddress>({
-    street: '',
-    number: '' as unknown as number,
-    complement: '',
-    neighborhood: '',
-    city: '',
-    state: '',
-    country: '',
-    zip: ''
-  });
-  const [addressErrors, setAddressErrors] = useState({
-    street: '',
-    number: '',
-    complement: '',
-    neighborhood: '',
-    city: '',
-    state: '',
-    country: '',
-    zip: ''
-  });
+  const [addressToEdit, setAddressToEdit] = useState<IAddress | undefined>(undefined);
 
   const handleJustifyClick = (value: string) => {
-    if (value === justifyActive) {
-      return;
-    }
+    if (value === justifyActive) return;
     setJustifyActive(value);
     window.location.hash = value;
   };
 
   const handleOpenModal = () => {
+    setAddressToEdit(undefined);
     setModalOpen(true);
-    setPendingApiCall(false);
-    setApiSuccess(false);
-    setApiError(false);
-  };
-
-  useEffect(() => {
-
-    const hash = window.location.hash.replace('#', '');
-    if (hash) {
-      setJustifyActive(hash);
-    }
-
-    const fetchUser = async () => {
-      try {
-        const response = await userService.findAll();
-        setUser(response.data[0]);
-        console.log(response.data);
-      } catch (error) {
-        console.error("An error occurred while loading the user data", error);
-      }
-    };
-
-    const fetchAddresses = async () => {
-      try {
-        const response = await addressService.findAll();
-        setAddresses(response.data);
-        console.log(response.data);
-
-      } catch (error) {
-        console.error("An error occurred while loading the addresses", error);
-      }
-    };
-
-    const fetchOrders = async () => {
-      try {
-        const response = await orderService.findAll();
-        setOrders(response.data);
-        console.log(response.data);
-
-      } catch (error) {
-        console.error("An error occurred while loading the orders", error);
-      }
-    };
-
-    fetchUser();
-    fetchAddresses();
-    fetchOrders();
-
-  }, []);
-
-  const handleAddressChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const { name, value } = event.target;
-    setNewAddress((previousAddress) => ({
-      ...previousAddress,
-      [name]: value,
-    }));
-
-    setAddressErrors((previousErrors) => ({
-      ...previousErrors,
-      [name]: '',
-    }));
   };
 
   const handleEditAddress = (address: IAddress) => {
-    setNewAddress(address);
+    setAddressToEdit(address);
     setModalOpen(true);
-    setPendingApiCall(false);
-    setApiSuccess(false);
-    setApiError(false);
   };
 
-  const handleDeleteAddress = async (iaddress: IAddress) => {
+  const handleDeleteAddress = async (address: IAddress) => {
     try {
-      await addressService.remove(iaddress);
-      setAddresses(addresses.filter(address => address.id !== iaddress.id));
+      await addressService.remove(address);
+      setAddresses((prev) => prev.filter((a) => a.id !== address.id));
     } catch (error) {
       console.error("An error occurred while deleting the address", error);
     }
   };
 
-  const handleSaveAddress = async () => {
-    setPendingApiCall(true);
-    setApiError(false);
-    setApiSuccess(false);
-
-    const addressToSave = {
-      ...newAddress,
-      number: parseInt(newAddress.number as unknown as string) || 0
-    };
-
-    let response;
-    if (newAddress.id) {
-      response = await addressService.update(addressToSave);
-    } else {
-      response = await addressService.save(addressToSave);
-    }
-
-    if (response.status === 200 || response.status === 201) {
-      setApiSuccess(true);
-      setTimeout(() => {
-        setModalOpen(false);
-        setNewAddress({
-          street: "", number: "" as unknown as number, complement: "", neighborhood: "", city: "", state: "", country: "", zip: "",
-        });
-        window.location.hash = 'tab2';
-        window.location.reload();
-      }, 2000);
-    } else {
-      if (response.data.validationErrors) {
-        setAddressErrors(response.data.validationErrors);
-      }
-      setApiError(true);
-      setPendingApiCall(false);
+  const fetchUser = async () => {
+    try {
+      const response = await userService.findAll();
+      setUser(response.data[0]);
+    } catch (error) {
+      console.error("Error loading user data", error);
     }
   };
 
-  const handleZipBlur = async () => {
-    if (newAddress.zip.length === 8) {
-      const addressData = await addressService.getAddressByCEP(newAddress.zip);
-      if (addressData) {
-        setNewAddress((prevAddress) => ({
-          ...prevAddress,
-          street: addressData.logradouro,
-          neighborhood: addressData.bairro,
-          city: addressData.localidade,
-          state: addressData.uf,
-          country: "Brasil",
-        }));
-      }
+  const fetchAddresses = async () => {
+    try {
+      const response = await addressService.findAll();
+      setAddresses(response.data);
+    } catch (error) {
+      console.error("Error loading addresses", error);
     }
+  };
+
+  const fetchOrders = async () => {
+    try {
+      const response = await orderService.findAll();
+      setOrders(response.data);
+    } catch (error) {
+      console.error("Error loading orders", error);
+    }
+  };
+
+  useEffect(() => {
+    const hash = window.location.hash.replace("#", "");
+    if (hash) {
+      setJustifyActive(hash);
+    }
+    fetchUser();
+    fetchAddresses();
+    fetchOrders();
+  }, []);
+
+  const handleAddressSaved = () => {
+    fetchAddresses();
   };
 
   return (
@@ -187,17 +89,26 @@ export function UserPage() {
         <div className="m-5">
           <MDBTabs pills justify className="mb-3">
             <MDBTabsItem>
-              <MDBTabsLink onClick={() => handleJustifyClick("tab1")} active={justifyActive === "tab1"}>
+              <MDBTabsLink
+                  onClick={() => handleJustifyClick("tab1")}
+                  active={justifyActive === "tab1"}
+              >
                 User Info
               </MDBTabsLink>
             </MDBTabsItem>
             <MDBTabsItem>
-              <MDBTabsLink onClick={() => handleJustifyClick("tab2")} active={justifyActive === "tab2"}>
+              <MDBTabsLink
+                  onClick={() => handleJustifyClick("tab2")}
+                  active={justifyActive === "tab2"}
+              >
                 Address Configuration
               </MDBTabsLink>
             </MDBTabsItem>
             <MDBTabsItem>
-              <MDBTabsLink onClick={() => handleJustifyClick("tab3")} active={justifyActive === "tab3"}>
+              <MDBTabsLink
+                  onClick={() => handleJustifyClick("tab3")}
+                  active={justifyActive === "tab3"}
+              >
                 Past Orders
               </MDBTabsLink>
             </MDBTabsItem>
@@ -209,11 +120,21 @@ export function UserPage() {
               <h5>User Details</h5>
               {user ? (
                   <>
-                    <p><strong>Name:</strong> {user.displayName}</p>
-                    <p><strong>Email:</strong> {user.email}</p> {/* Email */}
-                    <p><strong>Phone:</strong> {user.phone}</p> {/* Phone */}
-                    <p><strong>Birth Date:</strong> {user.birthDate}</p> {/* Birth Date */}
-                    <p><strong>Gender:</strong> {user.gender || "Not specified"}</p> {/* Gender */}
+                    <p>
+                      <strong>Name:</strong> {user.displayName}
+                    </p>
+                    <p>
+                      <strong>Email:</strong> {user.email}
+                    </p>
+                    <p>
+                      <strong>Phone:</strong> {user.phone}
+                    </p>
+                    <p>
+                      <strong>Birth Date:</strong> {user.birthDate}
+                    </p>
+                    <p>
+                      <strong>Gender:</strong> {user.gender || "Not specified"}
+                    </p>
                   </>
               ) : (
                   <p>Loading...</p>
@@ -221,28 +142,46 @@ export function UserPage() {
               <MDBBtn color="primary">Edit Profile</MDBBtn>
             </MDBTabsPane>
 
-            <MDBTabsContent>
-              <MDBTabsPane open={justifyActive === "tab2"}>
-                <h5>Saved Addresses</h5>
-                <MDBListGroup>
-                  {addresses.length > 0 ? (
-                      addresses.map((address) => (
-                          <MDBListGroupItem key={address.id} className="d-flex justify-content-between align-items-center">
-                            <div>
-                              {address.street}, {address.city}, {address.state} {address.zip}
-                            </div>
-                            <div className="d-flex">
-                              <MDBBtn className="me-2" size="sm" color="warning" onClick={() => handleEditAddress(address)}>Edit</MDBBtn>
-                              <MDBBtn size="sm" color="danger" onClick={() => handleDeleteAddress(address)}>Delete</MDBBtn>
-                            </div>
-                          </MDBListGroupItem>
-                      ))
-                  ) : (
-                      <p>No addresses available.</p>
-                  )}
-                </MDBListGroup>
-                <MDBBtn color="success" className="mt-3" onClick={handleOpenModal}>Add New Address</MDBBtn>              </MDBTabsPane>
-            </MDBTabsContent>
+            {/* Address Configuration Tab */}
+            <MDBTabsPane open={justifyActive === "tab2"}>
+              <h5>Saved Addresses</h5>
+              <MDBListGroup>
+                {addresses.length > 0 ? (
+                    addresses.map((address) => (
+                        <MDBListGroupItem
+                            key={address.id}
+                            className="d-flex justify-content-between align-items-center"
+                        >
+                          <div>
+                            {address.street}, {address.city}, {address.state} {address.zip}
+                          </div>
+                          <div className="d-flex">
+                            <MDBBtn
+                                className="me-2"
+                                size="sm"
+                                color="warning"
+                                onClick={() => handleEditAddress(address)}
+                            >
+                              Edit
+                            </MDBBtn>
+                            <MDBBtn
+                                size="sm"
+                                color="danger"
+                                onClick={() => handleDeleteAddress(address)}
+                            >
+                              Delete
+                            </MDBBtn>
+                          </div>
+                        </MDBListGroupItem>
+                    ))
+                ) : (
+                    <p>No addresses available.</p>
+                )}
+              </MDBListGroup>
+              <MDBBtn color="success" className="mt-3" onClick={handleOpenModal}>
+                Add New Address
+              </MDBBtn>
+            </MDBTabsPane>
 
             {/* Past Orders Tab */}
             <MDBTabsPane open={justifyActive === "tab3"}>
@@ -253,17 +192,25 @@ export function UserPage() {
                         <MDBCol md="6" lg="4" className="mb-4" key={order.id}>
                           <MDBCard>
                             <MDBCardBody>
-                              <MDBCardTitle>Order Date: {new Date(order.date).toLocaleDateString('en-GB')}</MDBCardTitle>
+                              <MDBCardTitle>
+                                Order Date:{" "}
+                                {new Date(order.date).toLocaleDateString("en-GB")}
+                              </MDBCardTitle>
                               <MDBCardText>
-                                <strong>Shipping:</strong> ${order.shipping.toFixed(2)}<br />
-                                <strong>Status:</strong> {order.status}<br />
-                                <strong>Payment:</strong> {order.payment}<br />
+                                <strong>Shipping:</strong> ${order.shipping.toFixed(2)}
+                                <br />
+                                <strong>Status:</strong> {order.status}
+                                <br />
+                                <strong>Payment:</strong> {order.payment}
+                                <br />
                                 <strong>Items:</strong>
                                 <ul>
                                   {order.items.map((item) => (
                                       <li key={item.productName}>
-                                        <strong>Product Name:</strong> {item.productName}<br />
-                                        <strong>Price:</strong> ${item.price.toFixed(2)}<br />
+                                        <strong>Product Name:</strong> {item.productName}
+                                        <br />
+                                        <strong>Price:</strong> ${item.price.toFixed(2)}
+                                        <br />
                                         <strong>Quantity:</strong> {item.quantity}
                                       </li>
                                   ))}
@@ -277,100 +224,17 @@ export function UserPage() {
                     <p>No past orders found.</p>
                 )}
               </MDBRow>
-            </MDBTabsPane>          </MDBTabsContent>
+            </MDBTabsPane>
+          </MDBTabsContent>
         </div>
 
-        {/* Modal for adding new address */}
-        <MDBModal open={modalOpen} setOpen={setModalOpen} tabIndex='-1'>
-          <MDBModalDialog>
-            <MDBModalContent>
-              <MDBModalHeader>
-                <MDBModalTitle>Add New Address</MDBModalTitle>
-                <MDBBtn className='btn-close' color='none' onClick={() => setModalOpen(false)}></MDBBtn>
-              </MDBModalHeader>
-              <MDBModalBody>
-                <MDBInput
-                    className={`mb-3 ${addressErrors.zip ? 'is-invalid' : ''}`}
-                    label="ZIP Code"
-                    value={newAddress.zip.replace(/\D/g, "")}
-                    onChange={handleAddressChange}
-                    onBlur={handleZipBlur}
-                    name="zip"
-                />
-                {addressErrors.zip && (<div className="invalid-feedback">{addressErrors.zip}</div>)}
-                <MDBInput
-                    className={`mb-3 ${addressErrors.street ? 'is-invalid' : ''}`}
-                    label="Street"
-                    value={newAddress.street}
-                    onChange={handleAddressChange}
-                    name="street"
-                />
-                {addressErrors.street && (<div className="invalid-feedback">{addressErrors.street}</div>)}
-                <MDBInput
-                    className={`mb-3 ${addressErrors.number ? 'is-invalid' : ''}`}
-                    label="Number" type="number"
-                    value={newAddress.number}
-                    onChange={handleAddressChange}
-                    name="number"
-                />
-                {addressErrors.number && (<div className="invalid-feedback">{addressErrors.number}</div>)}
-                <MDBInput
-                    className={`mb-3 ${addressErrors.complement ? 'is-invalid' : ''}`}
-                    label="Complement"
-                    value={newAddress.complement}
-                    onChange={handleAddressChange}
-                    name="complement"
-                />
-                {addressErrors.complement && (<div className="invalid-feedback">{addressErrors.complement}</div>)}
-                <MDBInput
-                    className={`mb-3 ${addressErrors.neighborhood ? 'is-invalid' : ''}`}
-                    label="Neighborhood"
-                    value={newAddress.neighborhood}
-                    onChange={handleAddressChange}
-                    name="neighborhood"
-                />
-                {addressErrors.neighborhood && (<div className="invalid-feedback">{addressErrors.neighborhood}</div>)}
-                <MDBInput
-                    className={`mb-3 ${addressErrors.city ? 'is-invalid' : ''}`}
-                    label="City"
-                    value={newAddress.city}
-                    onChange={handleAddressChange}
-                    name="city"
-                />
-                {addressErrors.city && (<div className="invalid-feedback">{addressErrors.city}</div>)}
-                <MDBInput
-                    className={`mb-3 ${addressErrors.state ? 'is-invalid' : ''}`}
-                    label="State"
-                    value={newAddress.state}
-                    onChange={handleAddressChange}
-                    name="state"
-                />
-                {addressErrors.state && (<div className="invalid-feedback">{addressErrors.state}</div>)}
-                <MDBInput
-                    className={`mb-3 ${addressErrors.country ? 'is-invalid' : ''}`}
-                    label="Country"
-                    value={newAddress.country}
-                    onChange={handleAddressChange}
-                    name="country"
-                />
-                {addressErrors.country && (<div className="invalid-feedback">{addressErrors.country}</div>)}
-              </MDBModalBody>
-              <MDBModalFooter>
-                <MDBBtn color="secondary" onClick={() => setModalOpen(false)}>Close</MDBBtn>
-                <ButtonWithProgress
-                    disabled={pendingApiCall}
-                    pendingApiCall={pendingApiCall}
-                    className="btn btn-primary"
-                    text="Save Address"
-                    onClick={handleSaveAddress}
-                />
-              </MDBModalFooter>
-              {apiError && <div className="alert alert-danger">Failed to save address!</div>}
-              {apiSuccess && <div className="alert alert-success">Address saved successfully!</div>}
-            </MDBModalContent>
-          </MDBModalDialog>
-        </MDBModal>
-
+        {/* Reusable modal component */}
+        <AddAddressModal
+            modalOpen={modalOpen}
+            setModalOpen={setModalOpen}
+            onAddressSaved={handleAddressSaved}
+            addressToEdit={addressToEdit}
+        />
       </main>
   );
 }


### PR DESCRIPTION
This pull request introduces significant changes to the `src/components/add-address-modal/index.tsx` and `src/pages/user/index.tsx` files to add a new modal for address management and improve the user page. The most important changes include the creation of the `AddAddressModal` component, refactoring the user page to integrate this new modal, and enhancing the display of user details and past orders.

### New Features and Enhancements:

* **Add Address Modal:**
  - Created `AddAddressModal` component to handle adding and editing addresses with form validation and API integration.

* **User Page Refactor:**
  - Integrated `AddAddressModal` into the user page, replacing the previous address handling logic.
  - Added functionality to edit and delete addresses directly from the user page.
  - Improved display formatting for user details and past orders for better readability. [[1]](diffhunk://#diff-bb4ee93cc9e3cd6dbf9cf3031b451340c56cef580ca8f62493b43f1755e1292dL212-R184) [[2]](diffhunk://#diff-bb4ee93cc9e3cd6dbf9cf3031b451340c56cef580ca8f62493b43f1755e1292dL256-R213)

### Codebase Improvements:

* **Code Cleanup:**
  - Removed redundant state and functions related to address handling from the user page.
  - Enhanced error handling and logging for API calls.

These changes streamline the address management process and enhance the overall user experience on the user page.